### PR TITLE
add method for checking whether messaging is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ React Native module bridge to iOS MFMessageComposeViewController
 
 Both the `args` object and `callback` function are required. The `args` object can be empty though ( e.g. { } ) if you don't want to populate the view with any initial data.
 
+`messagingSupported(callback)` - returns a boolean value indicating whether or not
+the device supports messaging. This allows you to determine whether or not messaging
+will work before actually attempting to open a message.
+
 ### Args
 
 The args object lets you prepopulate the MFMessageComposeViewController for the user. You can use the following parameters:
@@ -62,6 +66,10 @@ Composer.NotSupported - device does not support sending messages
 ```js
 var React = require('react-native');
 var Composer = require('NativeModules').RNMessageComposer;
+
+Composer.messagingSupported(supported => {
+	//do something like change the view based on whether or not messaging is supported
+});
 
 // inside your code where you would like to send a message
 Composer.composeMessageWithArgs(

--- a/RNMessageComposer/RNMessageComposer.m
+++ b/RNMessageComposer/RNMessageComposer.m
@@ -42,6 +42,11 @@
 
 RCT_EXPORT_MODULE()
 
+RCT_EXPORT_METHOD(messagingSupported:(RCTResponseSenderBlock)callback)
+{
+    callback(@[[NSNumber numberWithBool:[MFMessageComposeViewController canSendText]]]);
+}
+
 RCT_EXPORT_METHOD(composeMessageWithArgs:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
     // check the device can actually send messages - return from method if not supported

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-message-composer",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React Native module bridge to iOS MFMessageComposeViewController",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This is useful if you want to change the display based on whether or
not the device supports messaging without actually trying to send a
message.